### PR TITLE
Add early out after a set number of errors and kernel invocation collection

### DIFF
--- a/src/nixnan.cu
+++ b/src/nixnan.cu
@@ -288,8 +288,8 @@ void recv_thread_fun(std::shared_ptr<nixnan::recorder> recorder, ChannelHost cha
         num_processed_bytes += sizeof(exception_info);
         error_count++;
         if (max_errors > 0 && error_count >= max_errors) {
-          nnout() << "Maximum number of errors (" << max_errors << ") reached. Terminating program." << std::endl;
-          raise(SIGTERM);
+          nnout() << "Maximum number of errors (" << max_errors << ") reached. Sending SIGINT to the program." << std::endl;
+          raise(SIGINT);
         }
       }
     }

--- a/src/nixnan.cu
+++ b/src/nixnan.cu
@@ -74,6 +74,7 @@ std::unordered_set<CUfunction> instrumented_functions;
 
 bool skip_flag = false;
 long max_errors = 0;
+bool kernel_logging_enabled = false;
 
 void nvbit_at_init() {
   // Disable warning about using CUDA API calls in nvbit_at_init.
@@ -107,6 +108,18 @@ void nvbit_at_init() {
               "Disable debug information for source code locations. Having this enabled may cause crashes, so set this to 0 if you encounter issues.");
   if (!filename.empty()) {
     set_out_file(filename);
+  }
+
+  std::string kl_path;
+  GET_VAR_STR(kl_path, "LOG_KERNELS",
+              "Path to a log file containing the sequence of kernel "
+              "invocations. When set, this will disable "
+              "instrumentation; instead the program will be allowed to run "
+              "normally so interesting kernels can be identified. The log file "
+              "will contain the sequence of kernel invocations");
+  if (!kl_path.empty()) {
+    set_out_file(kl_path);
+    kernel_logging_enabled = true;
   }
   GET_VAR_INT(max_errors, "MAX_ERRORS", 0, "Maximum number of errors to report before stopping the program. Default is 0, which means no limit.");
   if (max_errors < 0) {
@@ -310,7 +323,10 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       } else {
         enable_instr = true;
       }
-
+      enable_instr &= !kernel_logging_enabled;
+      if (kernel_logging_enabled) {
+        nnout() << "kernel [" << kernel_name << "] ..." << std::endl;
+      }
       if (sampling != 0 && analyzed_kernels.count(short_name)) {
         if (analyzed_kernels[short_name] % sampling != 0) {
           ++analyzed_kernels[short_name];
@@ -364,6 +380,9 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 }
 
 void nvbit_tool_init(CUcontext ctx) {
+  if (kernel_logging_enabled) {
+    return;
+  }
   std::string k_whitelist_name = "kernel_whitelist.txt";
   std::string k_blacklist_name = "kernel_blacklist.txt";
 
@@ -390,6 +409,9 @@ void nvbit_at_ctx_term(CUcontext ctx) {
   if (recv_thread_started) {
     recv_thread_started = false;
     recv_thread.join();
+  }
+  if (kernel_logging_enabled) {
+    return;
   }
   recorder->end();
   recorder->free_device();

--- a/src/nixnan.cu
+++ b/src/nixnan.cu
@@ -44,6 +44,7 @@ using nixnan::exception_info;
 #include "nnout.hh"
 #include "meminstrumentation.cuh"
 #include "fp-histogram.cuh"
+#include <signal.h>
 
 uint32_t instr_begin_interval = 0;
 uint32_t instr_end_interval = UINT32_MAX;
@@ -72,6 +73,7 @@ std::shared_ptr<nixnan::recorder> recorder = nullptr;
 std::unordered_set<CUfunction> instrumented_functions;
 
 bool skip_flag = false;
+long max_errors = 0;
 
 void nvbit_at_init() {
   // Disable warning about using CUDA API calls in nvbit_at_init.
@@ -105,6 +107,11 @@ void nvbit_at_init() {
               "Disable debug information for source code locations. Having this enabled may cause crashes, so set this to 0 if you encounter issues.");
   if (!filename.empty()) {
     set_out_file(filename);
+  }
+  GET_VAR_INT(max_errors, "MAX_ERRORS", 0, "Maximum number of errors to report before stopping the program. Default is 0, which means no limit.");
+  if (max_errors < 0) {
+    nnout() << "Invalid value for MAX_ERRORS: " << max_errors << ". It must be a non-negative integer." << std::endl;
+    exit(1);
   }
   std::string pad(82, '-');
   nnout() << pad << '\n';
@@ -209,6 +216,7 @@ __global__ void flush_channel() {
 
 void recv_thread_fun(std::shared_ptr<nixnan::recorder> recorder, ChannelHost channel_host) {
   char *recv_buffer = new char[CHANNEL_SIZE];
+  static long error_count = 0;
 
   while (recv_thread_started) {
     uint32_t num_recv_bytes = 0;
@@ -265,6 +273,11 @@ void recv_thread_fun(std::shared_ptr<nixnan::recorder> recorder, ChannelHost cha
         nnout() << "error [" << errors << "] detected in operand " << ei->operand() << " of instruction " << instr << " in function "
                   << func << source_location << " of type " << type << std::endl;
         num_processed_bytes += sizeof(exception_info);
+        error_count++;
+        if (max_errors > 0 && error_count >= max_errors) {
+          nnout() << "Maximum number of errors (" << max_errors << ") reached. Terminating program." << std::endl;
+          raise(SIGTERM);
+        }
       }
     }
   }


### PR DESCRIPTION
This adds two new flags: first, `MAX_ERRORS` which sends a signal to the instrumented program when `MAX_ERRORS` exceptions are reported to the user.  And `LOG_KERNELS` which is a path to which kernel invocations will be logged. No instrumentation is performed when logging kernel invocations.